### PR TITLE
Fix failure on ID token validation if 'nbf' is not present

### DIFF
--- a/src/Shared/IdentityTokenValidation/DefaultIdentityTokenValidator.cs
+++ b/src/Shared/IdentityTokenValidation/DefaultIdentityTokenValidator.cs
@@ -43,19 +43,22 @@ namespace IdentityModel.OidcClient.IdentityTokenValidation
                 return Task.FromResult(fail);
             }
 
-            var exp = payload["exp"].ToString();
-            var nbf = payload["nbf"].ToString();
+            var exp = payload.Value<long>("exp");
+            var nbf = payload.Value<long?>("nbf");
 
             var utcNow = DateTime.UtcNow;
-            var notBefore = long.Parse(nbf).ToDateTimeFromEpoch();
-            var expires = long.Parse(exp).ToDateTimeFromEpoch();
 
-            if (notBefore > utcNow.Add(ClockSkew))
+            if (nbf != null)
             {
-                fail.Error = "Token not valid yet";
-                return Task.FromResult(fail);
+                var notBefore = nbf.Value.ToDateTimeFromEpoch();
+                if (notBefore > utcNow.Add(ClockSkew))
+                {
+                    fail.Error = "Token not valid yet";
+                    return Task.FromResult(fail);
+                }
             }
 
+            var expires = exp.ToDateTimeFromEpoch();
             if (expires < utcNow.Add(ClockSkew.Negate()))
             {
                 fail.Error = "Token expired";


### PR DESCRIPTION
This fixes #16. Tested with Google and IdentityServer (online demo). Probably should have unit tests on that class... Maybe I'll add them later. Which unit test framework do you prefer?
