### PR TITLE
Added support for PKCE without static client secret 

### DIFF
--- a/src/Shared/AuthorizeClient.cs
+++ b/src/Shared/AuthorizeClient.cs
@@ -94,6 +94,8 @@ namespace IdentityModel.OidcClient
         {
             var state = new AuthorizeState();
 
+            //Raphael Londner, 2016/08/18, State parameter is required by some identity providers (along with nonce)
+            state.State = RNG.CreateUniqueId();
             state.Nonce = RNG.CreateUniqueId();
             state.RedirectUri = _options.RedirectUri;
 
@@ -106,6 +108,7 @@ namespace IdentityModel.OidcClient
         private string CreateCodeChallenge(AuthorizeState state)
         {
             state.CodeVerifier = RNG.CreateUniqueId();
+            state.CodeVerifier = "at83hsVcajT5nfc2FVnKSxI6bsuU2Tq2aoVhEFhEO1A";
             var sha256 = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithm.Sha256);
 
             var challengeBuffer = sha256.HashData(
@@ -126,7 +129,7 @@ namespace IdentityModel.OidcClient
             {
                 responseType = OidcConstants.ResponseTypes.Code;
             }
-            else if(_options.Style == OidcClientOptions.AuthenticationStyle.Hybrid)
+            else if (_options.Style == OidcClientOptions.AuthenticationStyle.Hybrid)
             {
                 responseType = OidcConstants.ResponseTypes.CodeIdToken;
             }
@@ -140,7 +143,8 @@ namespace IdentityModel.OidcClient
                 responseType: responseType,
                 scope: _options.Scope,
                 redirectUri: state.RedirectUri,
-                responseMode: _options.UseFormPost ? OidcConstants.ResponseModes.FormPost : null,
+                responseMode: _options.UseFormPost ? OidcConstants.ResponseModes.FormPost : OidcConstants.ResponseModes.Fragment,
+                state: state.State,
                 nonce: state.Nonce,
                 codeChallenge: codeChallenge,
                 codeChallengeMethod: OidcConstants.CodeChallengeMethods.Sha256,

--- a/src/Shared/AuthorizeClient.cs
+++ b/src/Shared/AuthorizeClient.cs
@@ -141,7 +141,7 @@ namespace IdentityModel.OidcClient
                 responseType: responseType,
                 scope: _options.Scope,
                 redirectUri: state.RedirectUri,
-                responseMode: _options.UseFormPost ? OidcConstants.ResponseModes.FormPost : OidcConstants.ResponseModes.Fragment,
+                responseMode: _options.UseFormPost ? OidcConstants.ResponseModes.FormPost : null,
                 state: state.State,
                 nonce: state.Nonce,
                 codeChallenge: codeChallenge,

--- a/src/Shared/AuthorizeClient.cs
+++ b/src/Shared/AuthorizeClient.cs
@@ -94,7 +94,6 @@ namespace IdentityModel.OidcClient
         {
             var state = new AuthorizeState();
 
-            //Raphael Londner, 2016/08/18, State parameter is required by some identity providers (along with nonce)
             state.State = RNG.CreateUniqueId();
             state.Nonce = RNG.CreateUniqueId();
             state.RedirectUri = _options.RedirectUri;
@@ -108,7 +107,6 @@ namespace IdentityModel.OidcClient
         private string CreateCodeChallenge(AuthorizeState state)
         {
             state.CodeVerifier = RNG.CreateUniqueId();
-            state.CodeVerifier = "at83hsVcajT5nfc2FVnKSxI6bsuU2Tq2aoVhEFhEO1A";
             var sha256 = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithm.Sha256);
 
             var challengeBuffer = sha256.HashData(

--- a/src/Shared/AuthorizeState.cs
+++ b/src/Shared/AuthorizeState.cs
@@ -6,6 +6,8 @@ namespace IdentityModel.OidcClient
 {
     public class AuthorizeState
     {
+        //Raphael Londner, 2016/08/18, State parameter is required by some identity providers (along with nonce)
+        public string State { get; set; }
         public string Nonce { get; set; }
         public string CodeVerifier { get; set; }
 

--- a/src/Shared/AuthorizeState.cs
+++ b/src/Shared/AuthorizeState.cs
@@ -6,7 +6,6 @@ namespace IdentityModel.OidcClient
 {
     public class AuthorizeState
     {
-        //Raphael Londner, 2016/08/18, State parameter is required by some identity providers (along with nonce)
         public string State { get; set; }
         public string Nonce { get; set; }
         public string CodeVerifier { get; set; }

--- a/src/Shared/OidcClient.cs
+++ b/src/Shared/OidcClient.cs
@@ -127,11 +127,11 @@ namespace IdentityModel.OidcClient
             return await ProcessClaims(authorizeResponse, tokenResponse, validationResult.Claims);
         }
 
-        
+
         private async Task<LoginResult> ValidateCodeFlowResponse(AuthorizeResponse authorizeResponse, AuthorizeState state)
         {
             var result = new LoginResult { Success = false };
-            
+
             // redeem code for tokens
             var tokenResponse = await RedeemCodeAsync(authorizeResponse.Code, state);
             if (tokenResponse.IsError || tokenResponse.IsHttpError)
@@ -314,7 +314,17 @@ namespace IdentityModel.OidcClient
         {
             var endpoint = (await _options.GetProviderInformationAsync()).TokenEndpoint;
 
-            var tokenClient = new TokenClient(endpoint, _options.ClientId, _options.ClientSecret);
+            TokenClient tokenClient = null;
+
+            //Raphael Londner, 2016/08/18 - this is handling the situation where we don't pass the client secret (typically PKCE)
+            if (_options.ClientSecret.IsMissing())
+            {
+                tokenClient = new TokenClient(endpoint, _options.ClientId, AuthenticationStyle.PostValues);
+            }
+            else
+            {
+                tokenClient = new TokenClient(endpoint, _options.ClientId, _options.ClientSecret);
+            }
             var tokenResult = await tokenClient.RequestAuthorizationCodeAsync(
                 code,
                 state.RedirectUri,

--- a/src/Shared/OidcClient.cs
+++ b/src/Shared/OidcClient.cs
@@ -316,7 +316,6 @@ namespace IdentityModel.OidcClient
 
             TokenClient tokenClient = null;
 
-            //Raphael Londner, 2016/08/18 - this is handling the situation where we don't pass the client secret (typically PKCE)
             if (_options.ClientSecret.IsMissing())
             {
                 tokenClient = new TokenClient(endpoint, _options.ClientId, AuthenticationStyle.PostValues);

--- a/src/Shared/OidcClientOptions.cs
+++ b/src/Shared/OidcClientOptions.cs
@@ -55,7 +55,6 @@ namespace IdentityModel.OidcClient
         {
             if (string.IsNullOrWhiteSpace(clientId)) throw new ArgumentNullException(nameof(clientId));
 
-            //Raphael Londner, 2016/08/18 - stopped throwing an error when clientSecret is not provided (typically in PKCE cases)
             //if (string.IsNullOrWhiteSpace(clientSecret)) throw new ArgumentNullException(nameof(clientSecret));
             if (string.IsNullOrWhiteSpace(scope)) throw new ArgumentNullException(nameof(scope));
             if (string.IsNullOrWhiteSpace(redirectUri)) throw new ArgumentNullException(nameof(redirectUri));

--- a/src/Shared/OidcClientOptions.cs
+++ b/src/Shared/OidcClientOptions.cs
@@ -54,7 +54,9 @@ namespace IdentityModel.OidcClient
         private OidcClientOptions(string clientId, string clientSecret, string scope, string redirectUri, IWebView webView = null, IIdentityTokenValidator validator = null)
         {
             if (string.IsNullOrWhiteSpace(clientId)) throw new ArgumentNullException(nameof(clientId));
-            if (string.IsNullOrWhiteSpace(clientSecret)) throw new ArgumentNullException(nameof(clientSecret));
+
+            //Raphael Londner, 2016/08/18 - stopped throwing an error when clientSecret is not provided (typically in PKCE cases)
+            //if (string.IsNullOrWhiteSpace(clientSecret)) throw new ArgumentNullException(nameof(clientSecret));
             if (string.IsNullOrWhiteSpace(scope)) throw new ArgumentNullException(nameof(scope));
             if (string.IsNullOrWhiteSpace(redirectUri)) throw new ArgumentNullException(nameof(redirectUri));
 


### PR DESCRIPTION
Proposing changes to solve https://github.com/IdentityModel/IdentityModel.OidcClient/issues/25 

Tested that it's backward-compatible with previous behavior required by IdentityServer3
